### PR TITLE
Understand URL-Path as Account-Domains to allow delegated accounts

### DIFF
--- a/src/mailaccount.class.js
+++ b/src/mailaccount.class.js
@@ -23,14 +23,14 @@ function MailAccount(settingsObj) {
 
    if (settingsObj.domain != null) {
       // This is a GAFYD account
-      mailURL += "/a/" + settingsObj.domain + "/";
+      if (settingsObj.domain[0] === '/') {
+        mailURL += settingsObj.domain;
+      } else {
+        mailURL += "/a/" + settingsObj.domain + "/";
+      }
    } else if (settingsObj.accountNr != null) {
       // This is a Google account with multiple sessions activated
-      if (settingsObj.accountNr[0] === '/') {
-        mailURL += settingsObj.accountNr;
-      } else {
-        mailURL += "/mail/u/" + settingsObj.accountNr + "/";
-      }
+      mailURL += "/mail/u/" + settingsObj.accountNr + "/";
    } else {
       // Standard one-session Gmail account
       mailURL += "/mail/";

--- a/src/mailaccount.class.js
+++ b/src/mailaccount.class.js
@@ -26,7 +26,11 @@ function MailAccount(settingsObj) {
       mailURL += "/a/" + settingsObj.domain + "/";
    } else if (settingsObj.accountNr != null) {
       // This is a Google account with multiple sessions activated
-      mailURL += "/mail/u/" + settingsObj.accountNr + "/";
+      if (settingsObj.accountNr[0] === '/') {
+        mailURL += settingsObj.accountNr;
+      } else {
+        mailURL += "/mail/u/" + settingsObj.accountNr + "/";
+      }
    } else {
       // Standard one-session Gmail account
       mailURL += "/mail/";


### PR DESCRIPTION
Doesn't do auto-discovery but at least allows me to add a delegated account to the list of accounts manually so that MailCheckerPlus checks that one too. Kinda workaround for

https://github.com/AndersSahlin/MailCheckerPlus/issues/19
