### PR TITLE
Fixing session error affecting all users

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -195,7 +195,7 @@ function reloadSettings() {
         localStorage["gc_check_gmail_off"] == "false") {
       // Check if user has enabled multiple sessions
       $.ajax({
-         url: "https://www.google.com/accounts/AddSession",
+         url: "https://accounts.google.com/AddSession",
          success: function (data) {
             // Multiple accounts active
             var matches = data.match(/([\S]+?@[\S]+)/ig);


### PR DESCRIPTION
It seems as if the AddSession URL was updated to a new location and
it has a new look and feel.

I don't know if you've seen all the messages in the Mail Checker Plus [support link](https://chrome.google.com/webstore/support/gffjhibehnempbkeheiccaincokdjbfe), but the extension stopped working a few days ago.

Even though this PR fixes part of the issue, multiple accounts support still doesn't work. This is due to the AddSession screen having changed, since it no longer contains a list of all the signed in accounts.
